### PR TITLE
Send tntID & thirdPartyID  in TargetIdentities response event only if available

### DIFF
--- a/code/target/src/main/java/com/adobe/marketing/mobile/target/TargetExtension.java
+++ b/code/target/src/main/java/com/adobe/marketing/mobile/target/TargetExtension.java
@@ -1384,8 +1384,16 @@ public class TargetExtension extends Extension {
      */
     void dispatchIdentity(final Event event) {
         final Map<String, Object> responseEventData = new HashMap<>();
-        responseEventData.put(TargetConstants.EventDataKeys.THIRD_PARTY_ID, targetState.getThirdPartyId());
-        responseEventData.put(TargetConstants.EventDataKeys.TNT_ID, targetState.getTntId());
+
+        // attach thirdPartyId to response event only if there is valid value
+        if (!StringUtils.isNullOrEmpty(targetState.getThirdPartyId())) {
+            responseEventData.put(TargetConstants.EventDataKeys.THIRD_PARTY_ID, targetState.getThirdPartyId());
+        }
+
+        // attach tntId to response event only if there is valid value
+        if (!StringUtils.isNullOrEmpty(targetState.getTntId())) {
+            responseEventData.put(TargetConstants.EventDataKeys.TNT_ID, targetState.getTntId());
+        }
         responseEventData.put(TargetConstants.EventDataKeys.SESSION_ID, targetState.getSessionId());
         final Event responseEvent = new Event.Builder(TargetConstants.EventName.IDENTITY_RESPONSE,
                 EventType.TARGET, EventSource.RESPONSE_IDENTITY)

--- a/code/target/src/test/java/com/adobe/marketing/mobile/target/TargetExtensionTests.java
+++ b/code/target/src/test/java/com/adobe/marketing/mobile/target/TargetExtensionTests.java
@@ -1886,7 +1886,12 @@ public class TargetExtensionTests {
     // TargetIdentitiesGetter
     //**********************************************************************************************
     @Test
-    public void testHandleTargetRequestIdentityEvent() {
+    public void testGetTargetIdentities_whenAllIDPresent() {
+        // setup
+        when(targetState.getThirdPartyId()).thenReturn(MOCK_THIRD_PARTY_ID);
+        when(targetState.getTntId()).thenReturn(MOCK_TNT_ID);
+        when(targetState.getSessionId()).thenReturn(MOCK_SESSION_ID);
+
         // test
         extension.handleTargetRequestIdentityEvent(noEventDataEvent());
 
@@ -1896,8 +1901,30 @@ public class TargetExtensionTests {
         assertEquals(EventType.TARGET, capturedEvent.getType());
         assertEquals(EventSource.RESPONSE_IDENTITY, capturedEvent.getSource());
         assertEquals(EventType.TARGET, capturedEvent.getType());
-        assertEquals(targetState.getThirdPartyId(), capturedEvent.getEventData().get(EventDataKeys.THIRD_PARTY_ID));
-        assertEquals(targetState.getTntId(), capturedEvent.getEventData().get(EventDataKeys.TNT_ID));
+        assertEquals(MOCK_THIRD_PARTY_ID, capturedEvent.getEventData().get(EventDataKeys.THIRD_PARTY_ID));
+        assertEquals(MOCK_TNT_ID, capturedEvent.getEventData().get(EventDataKeys.TNT_ID));
+        assertEquals(MOCK_SESSION_ID, capturedEvent.getEventData().get(EventDataKeys.SESSION_ID));
+    }
+
+
+    @Test
+    public void testGetTargetIdentities_whenNullTntIDAndThirdPartyID() {
+        // setup
+        when(targetState.getThirdPartyId()).thenReturn(null);
+        when(targetState.getTntId()).thenReturn(null);
+        when(targetState.getSessionId()).thenReturn(null);
+
+        // test
+        extension.handleTargetRequestIdentityEvent(noEventDataEvent());
+
+        // verify
+        verify(mockExtensionApi).dispatch(eventArgumentCaptor.capture());
+        final Event capturedEvent = eventArgumentCaptor.getValue();
+        assertEquals(EventType.TARGET, capturedEvent.getType());
+        assertEquals(EventSource.RESPONSE_IDENTITY, capturedEvent.getSource());
+        assertEquals(EventType.TARGET, capturedEvent.getType());
+        assertFalse(capturedEvent.getEventData().containsKey(EventDataKeys.THIRD_PARTY_ID));
+        assertFalse(capturedEvent.getEventData().containsKey(EventDataKeys.TNT_ID));
         assertEquals(targetState.getSessionId(), capturedEvent.getEventData().get(EventDataKeys.SESSION_ID));
     }
 


### PR DESCRIPTION
Making this similar to what we have in [iOS ](https://github.com/adobe/aepsdk-target-ios/blob/dev-v3.3.0/AEPTarget/Sources/Target.swift#L551-L556)