### PR TITLE
Remove Target.extensionVersion() test

### DIFF
--- a/code/target/src/test/java/com/adobe/marketing/mobile/target/TargetTests.java
+++ b/code/target/src/test/java/com/adobe/marketing/mobile/target/TargetTests.java
@@ -64,16 +64,6 @@ public class TargetTests {
     }
 
     @Test
-    public void test_extensionVersion() {
-        // test
-        final String extensionVersion = Target.extensionVersion();
-        assertEquals(
-                "extensionVersion API should return the correct version string.",
-                "3.0.0",
-                extensionVersion);
-    }
-
-    @Test
     public void testPrefetchContent_validprefetchList() {
         try (MockedStatic<MobileCore> mobileCoreMockedStatic =
                 Mockito.mockStatic(MobileCore.class)) {


### PR DESCRIPTION
Removing Target.extensionVersion() test since it uses hard coded version values, which would fail when the release version is updated using `update-version.yml` script

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
