### PR TITLE
Add timeout parameter to prefetchContent API

### DIFF
--- a/code/target/src/main/java/com/adobe/marketing/mobile/target/TargetConstants.java
+++ b/code/target/src/main/java/com/adobe/marketing/mobile/target/TargetConstants.java
@@ -161,6 +161,7 @@ final class TargetConstants {
         static final String TARGET_RESPONSE_EVENT_ID = "responseEventId";
         static final String TARGET_RESPONSE_PAIR_ID = "responsePairId";
         static final String TARGET_DATA_PAYLOAD = "data";
+        static final String API_TIMEOUT = "api.timeout";
         static final String A4T_SESSION_ID = "a.target.sessionId"; // For A4T requests event data.
         static final String TARGET_CONTENT = "content";
         static final String ID = "id";

--- a/code/target/src/main/java/com/adobe/marketing/mobile/target/TargetExtension.java
+++ b/code/target/src/main/java/com/adobe/marketing/mobile/target/TargetExtension.java
@@ -1216,7 +1216,8 @@ public class TargetExtension extends Extension {
         headers.put(TargetConstants.HEADER_X_EXC_SDK, getSdkInfo(eventHubData));
         headers.put(TargetConstants.HEADER_X_EXC_SDK_VERSION, getSdkVersion(eventHubData));
 
-        final int timeout = targetState.getNetworkTimeout();
+        final int apiTimeout = DataReader.optInteger(event.getEventData(), TargetConstants.EventDataKeys.API_TIMEOUT, Integer.MAX_VALUE);
+        final int timeout = (apiTimeout == Integer.MAX_VALUE) ? targetState.getNetworkTimeout() : apiTimeout;
         final String url = getTargetRequestUrl();
         final String payloadJsonString = payloadJson.toString();
         final byte[] payload = payloadJsonString.getBytes(StandardCharsets.UTF_8);

--- a/code/target/src/main/java/com/adobe/marketing/mobile/target/TargetExtension.java
+++ b/code/target/src/main/java/com/adobe/marketing/mobile/target/TargetExtension.java
@@ -1216,8 +1216,13 @@ public class TargetExtension extends Extension {
         headers.put(TargetConstants.HEADER_X_EXC_SDK, getSdkInfo(eventHubData));
         headers.put(TargetConstants.HEADER_X_EXC_SDK_VERSION, getSdkVersion(eventHubData));
 
-        final int apiTimeout = DataReader.optInt(event.getEventData(), TargetConstants.EventDataKeys.API_TIMEOUT, Integer.MAX_VALUE);
-        final int timeout = (apiTimeout == Integer.MAX_VALUE) ? targetState.getNetworkTimeout() : apiTimeout;
+        final int apiTimeout =
+                DataReader.optInt(
+                        event.getEventData(),
+                        TargetConstants.EventDataKeys.API_TIMEOUT,
+                        Integer.MAX_VALUE);
+        final int timeout =
+                (apiTimeout == Integer.MAX_VALUE) ? targetState.getNetworkTimeout() : apiTimeout;
         final String url = getTargetRequestUrl();
         final String payloadJsonString = payloadJson.toString();
         final byte[] payload = payloadJsonString.getBytes(StandardCharsets.UTF_8);

--- a/code/target/src/main/java/com/adobe/marketing/mobile/target/TargetExtension.java
+++ b/code/target/src/main/java/com/adobe/marketing/mobile/target/TargetExtension.java
@@ -1216,7 +1216,7 @@ public class TargetExtension extends Extension {
         headers.put(TargetConstants.HEADER_X_EXC_SDK, getSdkInfo(eventHubData));
         headers.put(TargetConstants.HEADER_X_EXC_SDK_VERSION, getSdkVersion(eventHubData));
 
-        final int apiTimeout = DataReader.optInteger(event.getEventData(), TargetConstants.EventDataKeys.API_TIMEOUT, Integer.MAX_VALUE);
+        final int apiTimeout = DataReader.optInt(event.getEventData(), TargetConstants.EventDataKeys.API_TIMEOUT, Integer.MAX_VALUE);
         final int timeout = (apiTimeout == Integer.MAX_VALUE) ? targetState.getNetworkTimeout() : apiTimeout;
         final String url = getTargetRequestUrl();
         final String payloadJsonString = payloadJson.toString();

--- a/code/target/src/phone/java/com/adobe/marketing/mobile/Target.java
+++ b/code/target/src/phone/java/com/adobe/marketing/mobile/Target.java
@@ -119,6 +119,7 @@ public class Target {
             "The provided request map is empty or null";
 
     private static final long DEFAULT_TIMEOUT_MS = 5000L;
+    private static final long MS_PER_SECOND = 1000L;
     private static boolean isResponseListenerRegistered = false;
     private static final ConcurrentHashMap<String, TargetRequest> pendingTargetRequestsMap =
             new ConcurrentHashMap<>();
@@ -243,7 +244,7 @@ public class Target {
 
         MobileCore.dispatchEventWithResponseCallback(
                 event,
-                timeout == Integer.MAX_VALUE ? Long.MAX_VALUE : (long) timeout * 1000L,
+                timeout == Integer.MAX_VALUE ? Long.MAX_VALUE : (long) timeout * MS_PER_SECOND,
                 new AdobeCallbackWithError<Event>() {
                     @Override
                     public void fail(final AdobeError adobeError) {

--- a/code/target/src/phone/java/com/adobe/marketing/mobile/Target.java
+++ b/code/target/src/phone/java/com/adobe/marketing/mobile/Target.java
@@ -103,6 +103,7 @@ public class Target {
         static final String CLICK_METRIC_ANALYTICS_PAYLOAD = "clickmetric.analytics.payload";
         static final String TARGET_CONTENT = "content";
         static final String TARGET_DATA_PAYLOAD = "data";
+        static final String API_TIMEOUT = "api.timeout";
 
         private EventDataKeys() {}
     }
@@ -160,6 +161,33 @@ public class Target {
             @NonNull final List<TargetPrefetch> mboxPrefetchList,
             @Nullable final TargetParameters parameters,
             @Nullable final AdobeCallback<String> callback) {
+        prefetchContent(mboxPrefetchList, parameters, Integer.MAX_VALUE, callback);
+    }
+
+    /**
+     * Executes a prefetch request to the configured Target server with the TargetPrefetch list
+     * provided in the {@code mboxPrefetchList} parameter. This prefetch request will use the
+     * provided {@code parameters} for all of the prefetch made in this request. The {@code
+     * callback} will be executed when the prefetch has been completed, returning {@code null} if
+     * the prefetch was successful or will contain a {@code String} error message otherwise.
+     *
+     * @param mboxPrefetchList a {@code List<TargetPrefetch>} representing the desired mboxes to
+     *     prefetch
+     * @param parameters a {@code TargetParameters} object containing Target parameters for all
+     *     mboxes in the request list
+     * @param timeout the timeout in seconds to wait for the prefetch response
+     * @param callback an {@code AdobeCallback<String>} which will be called after the prefetch is
+     *     complete. The success parameter in the callback will be {@code null} if the prefetch
+     *     completed successfully, or will contain a {@code String} error message otherwise. If an
+     *     {@link AdobeCallbackWithError} is provided, an {@link AdobeError} can be returned in the
+     *     eventuality of an unexpected error or if the timeout is met before the content is
+     *     prefetched.
+     */
+    public static void prefetchContent(
+            @NonNull final List<TargetPrefetch> mboxPrefetchList,
+            @Nullable final TargetParameters parameters,
+            final int timeout,
+            @Nullable final AdobeCallback<String> callback) {
         final AdobeCallbackWithError<String> callbackWithError =
                 callback instanceof AdobeCallbackWithError
                         ? (AdobeCallbackWithError<String>) callback
@@ -200,6 +228,7 @@ public class Target {
 
         final Map<String, Object> eventData = new HashMap<>();
         eventData.put(EventDataKeys.PREFETCH, flattenedPrefetchRequests);
+        eventData.put(EventDataKeys.API_TIMEOUT, timeout);
         if (parameters != null) {
             eventData.put(EventDataKeys.TARGET_PARAMETERS, parameters.toEventData());
         }
@@ -214,7 +243,7 @@ public class Target {
 
         MobileCore.dispatchEventWithResponseCallback(
                 event,
-                DEFAULT_TIMEOUT_MS,
+                timeout == Integer.MAX_VALUE ? Long.MAX_VALUE : (long) timeout * 1000L,
                 new AdobeCallbackWithError<Event>() {
                     @Override
                     public void fail(final AdobeError adobeError) {

--- a/code/target/src/test/java/com/adobe/marketing/mobile/target/TargetExtensionTests.java
+++ b/code/target/src/test/java/com/adobe/marketing/mobile/target/TargetExtensionTests.java
@@ -2381,8 +2381,7 @@ public class TargetExtensionTests {
 
                     // test
                     extension.handleTargetRequestContentEvent(
-                            prefetchContentEvent(
-                                    getTargetPrefetchList(1), null, customTimeout));
+                            prefetchContentEvent(getTargetPrefetchList(1), null, customTimeout));
 
                     // verify network request uses the timeout value from event data
                     verify(networkService)
@@ -2390,13 +2389,9 @@ public class TargetExtensionTests {
                                     networkRequestCaptor.capture(),
                                     networkCallbackCaptor.capture());
                     assertEquals(
-                            customTimeout,
-                            networkRequestCaptor.getValue().getReadTimeout(),
-                            0);
+                            customTimeout, networkRequestCaptor.getValue().getReadTimeout(), 0);
                     assertEquals(
-                            customTimeout,
-                            networkRequestCaptor.getValue().getConnectTimeout(),
-                            0);
+                            customTimeout, networkRequestCaptor.getValue().getConnectTimeout(), 0);
                 });
     }
 

--- a/code/target/src/test/java/com/adobe/marketing/mobile/target/TargetExtensionTests.java
+++ b/code/target/src/test/java/com/adobe/marketing/mobile/target/TargetExtensionTests.java
@@ -2372,6 +2372,90 @@ public class TargetExtensionTests {
     }
 
     @Test
+    public void testHandlePrefetchContent_usesApiTimeoutFromEvent() {
+        runWithMockedServiceProvider(
+                () -> {
+                    // setup
+                    setEventHubSharedState();
+                    final int customTimeout = 10;
+
+                    // test
+                    extension.handleTargetRequestContentEvent(
+                            prefetchContentEvent(
+                                    getTargetPrefetchList(1), null, customTimeout));
+
+                    // verify network request uses the timeout value from event data
+                    verify(networkService)
+                            .connectAsync(
+                                    networkRequestCaptor.capture(),
+                                    networkCallbackCaptor.capture());
+                    assertEquals(
+                            customTimeout,
+                            networkRequestCaptor.getValue().getReadTimeout(),
+                            0);
+                    assertEquals(
+                            customTimeout,
+                            networkRequestCaptor.getValue().getConnectTimeout(),
+                            0);
+                });
+    }
+
+    @Test
+    public void testHandlePrefetchContent_fallsBackToNetworkTimeout_whenApiTimeoutIsIntMaxValue() {
+        runWithMockedServiceProvider(
+                () -> {
+                    // setup
+                    setEventHubSharedState();
+
+                    // test - Integer.MAX_VALUE signals no caller-specified timeout, use config
+                    extension.handleTargetRequestContentEvent(
+                            prefetchContentEvent(
+                                    getTargetPrefetchList(1), null, Integer.MAX_VALUE));
+
+                    // verify network request falls back to targetState.getNetworkTimeout()
+                    verify(networkService)
+                            .connectAsync(
+                                    networkRequestCaptor.capture(),
+                                    networkCallbackCaptor.capture());
+                    assertEquals(
+                            MOCK_NETWORK_TIMEOUT,
+                            networkRequestCaptor.getValue().getReadTimeout(),
+                            0);
+                    assertEquals(
+                            MOCK_NETWORK_TIMEOUT,
+                            networkRequestCaptor.getValue().getConnectTimeout(),
+                            0);
+                });
+    }
+
+    @Test
+    public void testHandlePrefetchContent_fallsBackToNetworkTimeout_whenApiTimeoutAbsent() {
+        runWithMockedServiceProvider(
+                () -> {
+                    // setup
+                    setEventHubSharedState();
+
+                    // test - no API_TIMEOUT key in event data, falls back to config timeout
+                    extension.handleTargetRequestContentEvent(
+                            prefetchContentEvent(getTargetPrefetchList(1), null));
+
+                    // verify network request falls back to targetState.getNetworkTimeout()
+                    verify(networkService)
+                            .connectAsync(
+                                    networkRequestCaptor.capture(),
+                                    networkCallbackCaptor.capture());
+                    assertEquals(
+                            MOCK_NETWORK_TIMEOUT,
+                            networkRequestCaptor.getValue().getReadTimeout(),
+                            0);
+                    assertEquals(
+                            MOCK_NETWORK_TIMEOUT,
+                            networkRequestCaptor.getValue().getConnectTimeout(),
+                            0);
+                });
+    }
+
+    @Test
     public void testHandlePrefetchContent_ReturnDefaultContent_When_ResponseNot200OK() {
         runWithMockedServiceProvider(
                 () -> {
@@ -3330,6 +3414,37 @@ public class TargetExtensionTests {
         final Event event =
                 new Event.Builder(
                                 EventName.LOAD_REQUEST,
+                                EventType.TARGET,
+                                EventSource.REQUEST_CONTENT)
+                        .setEventData(eventData)
+                        .build();
+
+        return event;
+    }
+
+    private Event prefetchContentEvent(
+            final List<TargetPrefetch> targetPrefetchList,
+            final TargetParameters parameters,
+            final int timeout) {
+        final List<TargetPrefetch> prefetchRequestListCopy = new ArrayList<>(targetPrefetchList);
+        final List<Map<String, Object>> flattenedPrefetchRequests = new ArrayList<>();
+        for (final TargetPrefetch request : prefetchRequestListCopy) {
+            if (request == null) {
+                continue;
+            }
+            flattenedPrefetchRequests.add(request.toEventData());
+        }
+
+        final Map<String, Object> eventData = new HashMap<>();
+        eventData.put(EventDataKeys.PREFETCH, flattenedPrefetchRequests);
+        eventData.put(TargetConstants.EventDataKeys.API_TIMEOUT, timeout);
+        if (parameters != null) {
+            eventData.put(EventDataKeys.TARGET_PARAMETERS, parameters.toEventData());
+        }
+
+        final Event event =
+                new Event.Builder(
+                                EventName.PREFETCH_REQUEST,
                                 EventType.TARGET,
                                 EventSource.REQUEST_CONTENT)
                         .setEventData(eventData)

--- a/code/target/src/test/java/com/adobe/marketing/mobile/target/TargetTests.java
+++ b/code/target/src/test/java/com/adobe/marketing/mobile/target/TargetTests.java
@@ -189,7 +189,8 @@ public class TargetTests {
                         }
                     });
 
-            // verify dispatchEventWithResponseCallback is called with timeout converted to ms (30s * 1000)
+            // verify dispatchEventWithResponseCallback is called with timeout converted to ms (30s
+            // * 1000)
             final ArgumentCaptor<Long> timeoutCaptor = ArgumentCaptor.forClass(Long.class);
             mobileCoreMockedStatic.verify(
                     () ->

--- a/code/target/src/test/java/com/adobe/marketing/mobile/target/TargetTests.java
+++ b/code/target/src/test/java/com/adobe/marketing/mobile/target/TargetTests.java
@@ -142,6 +142,92 @@ public class TargetTests {
     }
 
     @Test
+    public void testPrefetchContent_withTimeout_setsApiTimeoutInEventData() {
+        try (MockedStatic<MobileCore> mobileCoreMockedStatic =
+                Mockito.mockStatic(MobileCore.class)) {
+            // test
+            final List<TargetPrefetch> prefetchList = new ArrayList<>();
+            prefetchList.add(new TargetPrefetch("mbox1", null));
+
+            Target.prefetchContent(
+                    prefetchList,
+                    null,
+                    30,
+                    new AdobeCallback<String>() {
+                        @Override
+                        public void call(String value) {
+                            response = value;
+                        }
+                    });
+
+            // verify API_TIMEOUT is stored in event data with the passed value
+            final ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
+            mobileCoreMockedStatic.verify(
+                    () ->
+                            MobileCore.dispatchEventWithResponseCallback(
+                                    eventCaptor.capture(), anyLong(), any()));
+            assertEquals(30, eventCaptor.getValue().getEventData().get("api.timeout"));
+        }
+    }
+
+    @Test
+    public void testPrefetchContent_withTimeout_dispatchUsesConvertedMs() {
+        try (MockedStatic<MobileCore> mobileCoreMockedStatic =
+                Mockito.mockStatic(MobileCore.class)) {
+            // test
+            final List<TargetPrefetch> prefetchList = new ArrayList<>();
+            prefetchList.add(new TargetPrefetch("mbox1", null));
+
+            Target.prefetchContent(
+                    prefetchList,
+                    null,
+                    30,
+                    new AdobeCallback<String>() {
+                        @Override
+                        public void call(String value) {
+                            response = value;
+                        }
+                    });
+
+            // verify dispatchEventWithResponseCallback is called with timeout converted to ms (30s * 1000)
+            final ArgumentCaptor<Long> timeoutCaptor = ArgumentCaptor.forClass(Long.class);
+            mobileCoreMockedStatic.verify(
+                    () ->
+                            MobileCore.dispatchEventWithResponseCallback(
+                                    any(), timeoutCaptor.capture(), any()));
+            assertEquals(30000L, (long) timeoutCaptor.getValue());
+        }
+    }
+
+    @Test
+    public void testPrefetchContent_noTimeout_dispatchUsesLongMaxValue() {
+        try (MockedStatic<MobileCore> mobileCoreMockedStatic =
+                Mockito.mockStatic(MobileCore.class)) {
+            // test - 3-param overload defaults to Integer.MAX_VALUE which maps to Long.MAX_VALUE
+            final List<TargetPrefetch> prefetchList = new ArrayList<>();
+            prefetchList.add(new TargetPrefetch("mbox1", null));
+
+            Target.prefetchContent(
+                    prefetchList,
+                    null,
+                    new AdobeCallback<String>() {
+                        @Override
+                        public void call(String value) {
+                            response = value;
+                        }
+                    });
+
+            // verify dispatch is called with Long.MAX_VALUE (no caller-specified timeout)
+            final ArgumentCaptor<Long> timeoutCaptor = ArgumentCaptor.forClass(Long.class);
+            mobileCoreMockedStatic.verify(
+                    () ->
+                            MobileCore.dispatchEventWithResponseCallback(
+                                    any(), timeoutCaptor.capture(), any()));
+            assertEquals(Long.MAX_VALUE, (long) timeoutCaptor.getValue());
+        }
+    }
+
+    @Test
     public void testPrefetchContent_invalidPrefetchList() {
         try (MockedStatic<Log> logMockedStatic = Mockito.mockStatic(Log.class)) {
             // test


### PR DESCRIPTION
Introduces a new overload of prefetchContent() that accepts a timeout parameter (in seconds), consistent with the iOS SDK counterpart which uses TimeInterval (seconds).

## Description


The existing 3-param API is kept intact for backward compatibility and delegates to the new 4-param overload with Integer.MAX_VALUE, indicating no caller-specified timeout.

- Added API_TIMEOUT ("api.timeout") key to EventDataKeys in both Target.java and TargetConstants.java
- timeout is stored in the dispatched event data and forwarded to dispatchEventWithResponseCallback (converted to ms, Long.MAX_VALUE for Integer.MAX_VALUE case)
- In TargetExtension.sendTargetRequest(), timeout is extracted from the event data and falls back to targetState.getNetworkTimeout() if absent or Integer.MAX_VALUE

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
